### PR TITLE
Set default for param_value['NOISE_REUSED'] as NO

### DIFF
--- a/run_etc.py
+++ b/run_etc.py
@@ -88,6 +88,7 @@ if __name__ == '__main__':
     except:
         mag_file = param_value['MAG_FILE']
     ## reuse noise data ? ##
+    flag = '0'
     if param_value['NOISE_REUSED'].lower()=='y':
         flag='1'
     elif param_value['NOISE_REUSED'].lower()=='n':


### PR DESCRIPTION
seems no default value set to flag, possible to cause error if NOISE_REUSED is not y/n
