### PR TITLE
Fixed incorrect shift in PSF when calculating atmospheric transmission.

### DIFF
--- a/src/gsetc.c
+++ b/src/gsetc.c
@@ -858,7 +858,7 @@ void gsGetNoise(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double fiel
     lambda = lmin + (ipix+0.5)*dl;   
     printf("      --> %.0f percent done ...\r",0.02441*ipix);
     /* Atmospheric transmission -- used to remap the continuum model */
-    gsSpectroDist(spectro,obs,i_arm,lambda,7.5,0,SP_PSF_LEN,FR);
+    gsSpectroDist(spectro,obs,i_arm,lambda,SP_PSF_LEN/2-0.5,0,SP_PSF_LEN,FR);
     num = den = 0.;
     for(j=0;j<5*SP_PSF_LEN;j++) {
       trans = gsAtmTrans(obs,lambda+(0.2*j-SP_PSF_LEN/2+0.5)*dl,flags);


### PR DESCRIPTION
Dear @kiyoyabe , I've found this bug while debugging an issue with SNR in my updated version of the ETC. This causes a shift in the atmospheric transmission curve with respect to the sky continuum which isn't a big issue but I saw numerical differences everywhere until it got fixed. The hard-coded value of 7.5 is only correct when SP_PSF_LEN=16 but it's set to 64 by default. By the way I don't think using such a wide PSF is worth it, at least not at normal resolution.