### PR TITLE
Replace deprecated np.trapz with np.trapezoid for NumPy 2.0 compatibility

### DIFF
--- a/python/pfsspecsim/pfsspec.py
+++ b/python/pfsspecsim/pfsspec.py
@@ -40,8 +40,8 @@ def calculateFiberMagnitude(wav, mag, filterName):
 
     counts = np.exp(-mag)
     bandpass = np.where(np.logical_and(wav >= wav0, wav <= wav1), peak, 0)
-    fiberMag = -np.log(np.trapz(bandpass * counts, wav) /
-                       np.trapz(bandpass, wav))
+    fiberMag = -np.log(np.trapezoid(bandpass * counts, wav) /
+                       np.trapezoid(bandpass, wav))
     return fiberMag
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ def main():
         author="Kiyoto Yabe",
         author_email="kiyoto.yabe@ipmu.jp",
         url="",
-        install_requires=["scipy", "matplotlib"],
+        install_requires=["numpy>=2.0", "scipy", "matplotlib"],
         zip_safe=False,
         include_package_data=True,
         license="",  # temporarily set to an empty string as installation failed.


### PR DESCRIPTION
NumPy 2.0 removed `np.trapz` in favor of `np.trapezoid`. Updated the `calculateFiberMagnitude` function to use the new function name and added `numpy>=2.0` requirement to `setup.py` to ensure compatibility.
