### PR TITLE
Fix OpenMP data races and reduction clause misuse in gsetc_omp.c

### DIFF
--- a/src/gsetc_omp.c
+++ b/src/gsetc_omp.c
@@ -1576,7 +1576,7 @@ void gsGetSNR_Continuum(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, dou
     sample_factor = 1.2;
 #endif
 
-#pragma omp parallel for private(lambda, kk, p1, p2, mag, FR, trans, src_cont, counts, j) reduction(+ : num, den)
+#pragma omp parallel for private(lambda, kk, p1, p2, k, mag, FR, num, den, trans, src_cont, counts, j)
   for (ipix = 0; ipix < Npix; ipix++)
   {
 #ifndef QUIET_FOR_OMP

--- a/src/gsetc_omp.c
+++ b/src/gsetc_omp.c
@@ -999,7 +999,7 @@ void gsGetNoise(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double fiel
   printf("  --> Computing Sky Continuum Contribution ...\n");
 
 // #pragma omp parallel for private(lambda, j, num, den, trans, mag, lunar_cont, lunarphase, scale_RS, scale_MS, kV, alpha, Istar, f1, f2, Bmoon, count, FR) reduction(+ : num, den) reduction(* : continuum)
-#pragma omp parallel for private(lambda, j, trans, mag, lunar_cont, lunarphase, scale_RS, scale_MS, kV, alpha, Istar, f1, f2, Bmoon, count, FR) reduction(+ : num, den) reduction(* : continuum)
+#pragma omp parallel for private(lambda, j, num, den, trans, mag, lunar_cont, lunarphase, scale_RS, scale_MS, kV, alpha, Istar, f1, f2, Bmoon, count, continuum, FR)
   for (ipix = 0; ipix < Npix; ipix++)
   {
     lambda = lmin + (ipix + 0.5) * dl;

--- a/src/gsetc_omp.c
+++ b/src/gsetc_omp.c
@@ -804,7 +804,7 @@ double gsFracTrace(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double l
 /* --- ROUTINES TO COMPUTE THE SIGNAL AND THE NOISE --- */
 
 /* adjustment based on previous observations */
-/* 
+/*
  * Empirical noise adjustment factors for each spectrograph arm, derived from previous observations.
  * These factors are used to correct the estimated noise variance.
  * The values correspond to the [Blue, RedLR/RedMR, NIR] arms, respectively.
@@ -919,10 +919,10 @@ void gsGetNoise(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double fiel
         count *= airmass / 1.1 * exp(-gsAtmContOp(obs, lambda, flags) * airmass / 1.086);
 
         iref = (long)floor(pos - (SP_PSF_LEN/2 - 0.5));
-        if (iref < 0) 
+        if (iref < 0)
           iref = 0;
-        if (iref > Npix - SP_PSF_LEN) 
-        iref = Npix - SP_PSF_LEN;
+        if (iref > Npix - SP_PSF_LEN)
+          iref = Npix - SP_PSF_LEN;
         gsSpectroDist(spectro, obs, i_arm, lambda, pos - iref, 0, SP_PSF_LEN, FR);
         for(j = 0; j < SP_PSF_LEN; j++)
         {
@@ -1206,7 +1206,7 @@ void gsGetNoise(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double fiel
             Noise[ipix] *= adjust_noise_MR[i_arm];
     }
   }
-   
+
   free((char *)sky);
   return;
 }
@@ -1646,7 +1646,7 @@ void gsGetSNR_Continuum(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, dou
 /* --- I/O FUNCTIONS --- */
 
 /* adjustment based on previous observations */
-/* 
+/*
  * Empirical throughput adjustment factors for each spectrograph arm, derived from previous observations.
  * These factors are used to correct the throughput.
  * The values correspond to the [Blue, RedLR/RedMR, NIR] arms, respectively.
@@ -2330,7 +2330,7 @@ int main(void)
     {
       zarr[iz] = zmin + iz * dz;
     }
-#pragma omp parallel for ordered private(z, ia) reduction(+ : snrtot, Aeff)
+#pragma omp parallel for private(z, ia, snrtot, Aeff)
     for (int iz = 0; iz < nz; iz++)
     {
 #ifndef QUIET_FOR_OMP
@@ -2407,7 +2407,7 @@ int main(void)
       // printf("iz, zarr[iz]: %5d %.4f\n", iz, zarr[iz]);
     }
 
-#pragma omp parallel for ordered private(z, ia) reduction(+ : snrtot, Aeff)
+#pragma omp parallel for private(z, ia, snrtot, Aeff)
     for (int iz = 0; iz < nz; iz++)
     {
       z = zarr[iz];

--- a/src/gsetc_omp.c
+++ b/src/gsetc_omp.c
@@ -925,7 +925,10 @@ void gsGetNoise(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double fiel
         iref = Npix - SP_PSF_LEN;
         gsSpectroDist(spectro, obs, i_arm, lambda, pos - iref, 0, SP_PSF_LEN, FR);
         for(j = 0; j < SP_PSF_LEN; j++)
+        {
+          #pragma omp atomic
           Noise[iref+j] += count * FR[j] * sample_factor;
+        }
         /*
         iref = (long)floor(pos - 7.5);
         if (iref < 0)
@@ -977,8 +980,10 @@ void gsGetNoise(SPECTRO_ATTRIB *spectro, OBS_ATTRIB *obs, int i_arm, double fiel
 
         gsSpectroDist(spectro, obs, i_arm, lambda, pos - iref, 0, SP_PSF_LEN, FR);
         for (j = 0; j < SP_PSF_LEN; j++)
-
+        {
+          #pragma omp atomic
           Noise[iref + j] += count * FR[j] * sample_factor;
+        }
       }
     }
     break;


### PR DESCRIPTION
## Summary

This PR fixes critical OpenMP-related bugs in `gsetc_omp.c` that were causing data races and incorrect parallel reduction usage. The fixes ensure thread-safe execution and correct results that match the non-OpenMP version.

### Fixed Issues

1. **Data races in sky lines calculation** (L895-928, L945-981)
   - Added `#pragma omp atomic` directives to protect concurrent writes to the `Noise` array
   - Affected: UVES sky lines and NIR OH lines loops

2. **Reduction clause misuse in sky continuum** (L1002)
   - Moved `num`, `den`, `continuum` from `reduction` to `private` clause
   - These variables are reset each iteration and should not accumulate across iterations

3. **Missing private variable in source spectrum** (L1579)
   - Added loop variable `k` to private clause
   - Moved `num`, `den` from `reduction` to `private` clause

4. **Reduction clause misuse in SNR calculations** (L2333, L2410)
   - Moved `snrtot`, `Aeff` from `reduction` to `private` clause
   - Removed unnecessary `ordered` clause for better performance
   - These variables are recalculated each iteration, not accumulated

### Testing

All fixes have been tested using the test scripts in `tests/`:
- `noise_omp.dat`: Identical to non-OMP version ✓
- `snc_omp.dat`: Identical to non-OMP version ✓
- `snl_omp.dat`: Minor formatting differences due to floating-point rounding (max 0.01nm, relative error ~10⁻⁵)
- `sno2_omp.dat`: Minor formatting differences due to floating-point rounding (max 0.01nm, relative error ~10⁻⁵)

The small differences in `snl` and `sno2` files are due to parallel execution order affecting floating-point rounding at the output formatting boundary (`%.2lf`), not due to incorrect computation. Physical results (SNR values) are identical.

**Important**: These minor floating-point differences existed in the master branch before this fix and remain unchanged after the fix. The fixes address correctness issues without altering the numerical output.

### Branch Structure

This PR integrates 4 topic branches:
- `u/monodera/fix-omp-sky-lines-race`
- `u/monodera/fix-omp-sky-continuum-reduction`
- `u/monodera/fix-omp-source-spectrum-private`
- `u/monodera/fix-omp-snr-calculation-reduction`

All merges used `--no-ff` to preserve individual fix history.
