### PR TITLE
Feature/remove datamodel submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "python/pfsspecsim/datamodel"]
-	path = python/pfsspecsim/datamodel
-	url = https://github.com/Subaru-PFS/datamodel.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,6 @@ include _build_backend.py
 
 # Package data
 recursive-include python/pfsspecsim/config *
-recursive-include python/pfsspecsim/datamodel *
 recursive-include python/pfsspecsim/bin *
 
 # Scripts and configuration files

--- a/README.md
+++ b/README.md
@@ -31,30 +31,30 @@ Installation
 ------------
 To install the package, get the git repository by typing the following command on the terminal (if you have git installed):
 
-    git clone --recursive https://github.com/Subaru-PFS/spt_ExposureTimeCalculator.git
+    git clone https://github.com/Subaru-PFS/spt_ExposureTimeCalculator.git
     cd spt_ExposureTimeCalculator
     pip install .
 
 The C executables (gsetc.x and gsetc_omp.x) will be automatically compiled during the installation process.
 
+Note: The pfs.datamodel dependency will be automatically installed from GitHub during the pip install process.
+
 Once you clone the repository, you can pull updates from the next time on the directory like this:
 
     git pull
-    git submodule update --init
     pip install . --upgrade
 
 ### Alternative Installation with uv (Optional)
 
 If you prefer to use `uv` for package and dependency management:
 
-    git clone --recursive https://github.com/Subaru-PFS/spt_ExposureTimeCalculator.git
+    git clone https://github.com/Subaru-PFS/spt_ExposureTimeCalculator.git
     cd spt_ExposureTimeCalculator
     uv sync
 
 To update:
 
     git pull
-    git submodule update --init
     uv sync
 
 You also can get the zip or tar ball from the following page:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "scipy",
     "matplotlib",
     "astropy",
+    "pfs.datamodel @ git+https://github.com/Subaru-PFS/datamodel.git@w.2024.06",
 ]
 
 [project.optional-dependencies]
@@ -38,8 +39,6 @@ zip-safe = false
 include-package-data = true
 packages = [
     "pfsspecsim",
-    "pfsspecsim.datamodel.python.pfs",
-    "pfsspecsim.datamodel.python.pfs.datamodel",
     "pfsspecsim.scripts",
 ]
 

--- a/python/pfsspecsim/dm_utils.py
+++ b/python/pfsspecsim/dm_utils.py
@@ -2,16 +2,10 @@
 
 from __future__ import print_function, division
 
-import sys
-import os
-from os import path
 import numpy as np
 import collections
-import importlib
 
-HOME_DIR = path.dirname(path.abspath(__file__))
 # import datamodel module
-sys.path.append(HOME_DIR + "/datamodel/python")
 from pfs.datamodel.wavelengthArray import WavelengthArray
 from pfs.datamodel import FluxTable
 from pfs.datamodel import utils

--- a/python/pfsspecsim/pfsetc.py
+++ b/python/pfsspecsim/pfsetc.py
@@ -67,7 +67,7 @@ def calc_obscuration(dist):
 
 
 class Etc(object):
-    """ PFS ETC
+    """PFS ETC
 
     See https://github.com/Subaru-PFS/spt_ExposureTimeCalculator for details
 
@@ -80,7 +80,7 @@ class Etc(object):
     -------
 
     Examples
-    ----------    
+    ----------
     """
 
     def __init__(self, omp_num_threads=16):
@@ -142,7 +142,7 @@ class Etc(object):
         return None
 
     def set_param(self, param_name, param_value):
-        """ Set ETC parameters
+        """Set ETC parameters
 
         Parameters
         ----------
@@ -153,7 +153,7 @@ class Etc(object):
         -------
 
         Examples
-        ----------    
+        ----------
         """
         if param_name in self.params.keys():
             try:
@@ -235,7 +235,7 @@ class Etc(object):
         C = 0
         if self.params['OVERWRITE'].lower() == 'no' or self.params['OVERWRITE'].lower() == 'n':
             if os.path.exists(self.params['OUTFILE_NOISE']):
-                print("Error: %s already exists... " % (args.OUTFILE_NOISE))
+                print("Error: %s already exists... " % (self.params["OUTFILE_NOISE"]))
                 C += 1
             if os.path.exists(self.params['OUTFILE_SNC']):
                 print("Error: %s already exists... " %
@@ -253,7 +253,7 @@ class Etc(object):
             obsc, corr = calc_obscuration(float(self.params['FIELD_ANG']))
             degrade = float(self.params['degrade']) * corr
             self.params['degrade'] = f'{degrade}'
-        #print('The throughput degrade: %s' % (self.params['degrade']))
+        # print('The throughput degrade: %s' % (self.params['degrade']))
 
         # run ETC
         # print("Spectrograph setup : %s" % (self.INSTR_SETUP))
@@ -431,7 +431,7 @@ class Etc(object):
         C = 0
         if self.params['OVERWRITE'].lower() == 'no' or self.params['OVERWRITE'].lower() == 'n':
             if os.path.exists(self.params['OUTFILE_NOISE']):
-                print("Error: %s already exists... " % (args.OUTFILE_NOISE))
+                print("Error: %s already exists... " % (self.params["OUTFILE_NOISE"]))
                 C += 1
             if os.path.exists(self.params['OUTFILE_SNC']):
                 print("Error: %s already exists... " %


### PR DESCRIPTION
This PR move datamodel dependency from submodule to pyproject.toml

- Add pfs.datamodel@w.2024.06 as a git dependency in pyproject.toml
- Remove datamodel packages from setup packages list
- Remove datamodel from MANIFEST.in
- Update README.md installation instructions (remove --recursive and git submodule commands)
- Remove .gitmodules file
- Unregister datamodel submodule
- Clean up dm_utils.py: remove sys.path manipulation and unused imports

The pfs.datamodel will now be automatically installed from GitHub
during pip install, improving dependency management and removing the
need for manual submodule initialization.

Additionally, a minor bug (calling undefined variable `args`) in `pfsetc.py` is fixed.