### PR TITLE
Fix macOS build with GCC 16 and pin numpy<2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Release Note
 Requirements
 ------------
 * Standard C compiler (e.g., GCC) with OpenMP support
-  * **macOS users**: Homebrew-installed GCC (versions 10-15) is required for OpenMP support. Install with `brew install gcc`
+  * **macOS users**: Homebrew-installed GCC is required for OpenMP support. Install with `brew install gcc`. The newest installed version (`gcc-N`) is detected automatically at build time; a specific compiler can be selected with the `CC` environment variable (see Installation section below)
 * Python 3.9 or higher (Python2 is NOT supported)
-* numpy   (2.0 and higher)  see https://numpy.org/
+* numpy   (2.0 and higher, but below 2.5)  see https://numpy.org/
+  * The upper bound is needed because the currently pinned pfs.datamodel version uses a legacy dtype alias that was removed in numpy 2.5
 * scipy
 * matplotlib (for plotting options)
 * astropy (for FITS file handling and the PFS datamodel package)
@@ -36,7 +37,11 @@ To install the package, get the git repository by typing the following command o
     cd spt_ExposureTimeCalculator
     pip install .
 
-The C executables (gsetc.x and gsetc_omp.x) will be automatically compiled during the installation process.
+The C executables (gsetc.x and gsetc_omp.x) will be automatically compiled during the installation process. On macOS, the newest Homebrew GCC (`gcc-N`) is detected and used automatically. To build with a specific compiler instead, set the `CC` environment variable:
+
+    CC=gcc-12 pip install .
+
+Note: if the executables were already built with another compiler, run `make clean` first so that they are recompiled.
 
 Note: The pfs.datamodel dependency will be automatically installed from GitHub during the pip install process.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ authors = [
 ]
 
 dependencies = [
-    "numpy>=2.0",
+    # <2.5: datamodel w.2024.06 uses the 'a' dtype alias removed in numpy 2.5;
+    # drop this bound once the datamodel pin is updated past the '|S' fix
+    "numpy>=2.0,<2.5",
     "scipy",
     "matplotlib",
     "astropy",

--- a/src/Makefile.omp
+++ b/src/Makefile.omp
@@ -9,17 +9,14 @@ ifeq ($(UNAME_S), Darwin)
     HOMEBREW_PREFIX := $(shell brew --prefix 2>/dev/null)
 
     ifneq ($(HOMEBREW_PREFIX),)
-        # Search for the newest available GCC
-        GCC_CANDIDATES := gcc-15 gcc-14 gcc-13 gcc-12 gcc-11 gcc-10
-
-        # Find the first candidate that exists in the brew bin directory
-        # (Using 'wildcard' is slightly faster/cleaner than shell which in loop)
-        GCC_FOUND := $(firstword $(foreach ver,$(GCC_CANDIDATES),$(wildcard $(HOMEBREW_PREFIX)/bin/$(ver))))
+        # Pick the newest Homebrew GCC (gcc-N) actually installed,
+        # so new major versions (gcc-16, gcc-17, ...) work without edits
+        GCC_FOUND := $(shell ls $(HOMEBREW_PREFIX)/bin/gcc-[0-9]* 2>/dev/null | sort -t- -k2,2nr | head -n1)
 
         ifneq ($(GCC_FOUND),)
             CC := $(GCC_FOUND)
         else
-            $(error OpenMP-capable GCC not found. Please install: brew install gcc)
+            $(error OpenMP-capable GCC not found. Install with 'brew install gcc', or specify one: make CC=/path/to/gcc)
         endif
     else
         $(warning Homebrew not found. Using system compiler (OpenMP might fail).)

--- a/src/Makefile.omp
+++ b/src/Makefile.omp
@@ -5,21 +5,25 @@ CC ?= gcc
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S), Darwin)
-    # Check Homebrew prefix (works for both M1/M2 and Intel)
-    HOMEBREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+    # Respect a user-supplied CC (environment or command line, e.g.
+    # 'CC=gcc-12 pip install -e .'); autodetect only when CC is make's default
+    ifeq ($(origin CC),default)
+        # Check Homebrew prefix (works for both M1/M2 and Intel)
+        HOMEBREW_PREFIX := $(shell brew --prefix 2>/dev/null)
 
-    ifneq ($(HOMEBREW_PREFIX),)
-        # Pick the newest Homebrew GCC (gcc-N) actually installed,
-        # so new major versions (gcc-16, gcc-17, ...) work without edits
-        GCC_FOUND := $(shell ls $(HOMEBREW_PREFIX)/bin/gcc-[0-9]* 2>/dev/null | sort -t- -k2,2nr | head -n1)
+        ifneq ($(HOMEBREW_PREFIX),)
+            # Pick the newest Homebrew GCC (gcc-N) actually installed,
+            # so new major versions (gcc-16, gcc-17, ...) work without edits
+            GCC_FOUND := $(shell ls $(HOMEBREW_PREFIX)/bin/gcc-[0-9]* 2>/dev/null | sort -t- -k2,2nr | head -n1)
 
-        ifneq ($(GCC_FOUND),)
-            CC := $(GCC_FOUND)
+            ifneq ($(GCC_FOUND),)
+                CC := $(GCC_FOUND)
+            else
+                $(error OpenMP-capable GCC not found. Install with 'brew install gcc', or specify one: make CC=/path/to/gcc)
+            endif
         else
-            $(error OpenMP-capable GCC not found. Install with 'brew install gcc', or specify one: make CC=/path/to/gcc)
+            $(warning Homebrew not found. Using system compiler (OpenMP might fail).)
         endif
-    else
-        $(warning Homebrew not found. Using system compiler (OpenMP might fail).)
     endif
 endif
 

--- a/src/Makefile.omp
+++ b/src/Makefile.omp
@@ -1,5 +1,5 @@
-# Default compiler (overridden below on macOS)
-CC ?= gcc
+# CC defaults to make's builtin ('cc'); on macOS the newest Homebrew GCC is
+# autodetected below unless the user supplies CC themselves.
 
 # --- Platform & Compiler Detection ---
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
## Summary

- **Makefile.omp**: replace the hardcoded `GCC_CANDIDATES := gcc-15 ... gcc-10` list with dynamic detection that picks the newest Homebrew `gcc-N` actually installed. This fixes the reported build failure with GCC 16 and avoids having to extend the list on every GCC major release. The previous logic also silently preferred an older listed version (e.g. gcc-12) over an unlisted newer one. The `$(error)` message now also mentions the `make CC=/path/to/gcc` override for non-Homebrew compilers (MacPorts, conda, etc.).
- **pyproject.toml**: constrain `numpy>=2.0,<2.5`. The pinned `pfs.datamodel w.2024.06` uses the `'a'` dtype alias (`dtype='a7'`) that was deprecated in numpy 2.0 and removed in 2.5.0, which made `pfs-gen-sim-spec` crash in `GuideStars.empty()`. Upstream datamodel already uses `'|S7'` on master, so this bound can be dropped once the datamodel pin is updated.

## Test plan

- [x] `make -f Makefile.omp clean all` in `src/` on macOS with gcc-12 and gcc-16 both installed: gcc-16 is selected and the build succeeds
- [x] `sort -t- -k2,2nr` verified with BSD sort; `gcc-[0-9]*` does not match auxiliary tools like `gcc-ar-16`
- [x] `uv sync` resolves numpy 2.4.6; `GuideStars.empty()` and `dm_utils.makePfsDesign()` succeed
- [x] End-to-end: `uv run pfs-gen-sim-spec --etcFile=out/ref.snc.dat` in `tests/test_gcc16` completes and regenerates all output FITS files