### PR TITLE
Make uv sync rebuild C executables when build inputs change

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The C executables (gsetc.x and gsetc_omp.x) will be automatically compiled durin
 
     CC=gcc-12 pip install .
 
-Note: if the executables were already built with another compiler, run `make clean` first so that they are recompiled.
+The executables are recompiled from a clean state whenever the build runs, so switching compilers does not require a manual `make clean`.
 
 Note: The pfs.datamodel dependency will be automatically installed from GitHub during the pip install process.
 
@@ -57,11 +57,17 @@ If you prefer to use `uv` for package and dependency management:
     git clone https://github.com/Subaru-PFS/spt_ExposureTimeCalculator.git
     cd spt_ExposureTimeCalculator
     uv sync
+    # or, to install into an existing environment instead of the project .venv:
+    uv pip install .
 
 To update:
 
     git pull
     uv sync
+    # or
+    uv pip install . --upgrade
+
+Note: `uv sync` rebuilds the C executables only when it detects a change in the build inputs declared in `pyproject.toml` (`[tool.uv] cache-keys`: currently `pyproject.toml` itself, the C sources and Makefiles under `src/`, and the `CC` environment variable). To force a rebuild manually, run `uv sync --reinstall-package pfsspecsim`.
 
 You also can get the zip or tar ball from the following page:
 

--- a/_build_backend.py
+++ b/_build_backend.py
@@ -32,7 +32,10 @@ def _compile_executables():
     print("Building C executables (gsetc.x and gsetc_omp.x)")
     print("=" * 60)
 
-    cmd = ["make", "-f", "Makefile", "all"]
+    # Build from clean: this function only runs when uv/pip decide a rebuild
+    # is needed (see [tool.uv] cache-keys), and a stale object file compiled
+    # with a different CC would otherwise be reused as-is
+    cmd = ["make", "-f", "Makefile", "clean", "all"]
 
     try:
         result = subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,18 @@ dev = [
     "ty>=0.0.8"
 ]
 
+[tool.uv]
+# Rebuild the project (and thus the C executables via _build_backend.py) when
+# the C sources, Makefiles, or the CC environment variable change; by default
+# uv only watches pyproject.toml/setup.py/setup.cfg and would skip make
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "src/**/*.c" },
+    { file = "src/**/*.h" },
+    { file = "src/Makefile*" },
+    { env = "CC" },
+]
+
 [project.scripts]
 pfs-run-etc = "pfsspecsim.scripts.run_etc:main"
 pfs-gen-sim-spec = "pfsspecsim.scripts.gen_sim_spec:main"


### PR DESCRIPTION
## Summary

- **pyproject.toml**: add `[tool.uv] cache-keys` so `uv sync` re-invokes the build backend when the C sources / Makefiles under `src/` or the `CC` environment variable change. By default uv only watches `pyproject.toml`/`setup.py`/`setup.cfg`, so `uv sync` never re-ran `make` after C-side changes (or after `make clean`).
- **_build_backend.py**: run `make clean all` instead of `make all`. The backend now only runs when a rebuild is actually wanted (per the cache keys), and without the clean a stale object file compiled with a different `CC` would be reused as-is, producing a binary with the wrong compiler.
- **README.md**: document `uv pip install .` alongside `uv sync`, explain when `uv sync` rebuilds the executables and how to force it (`uv sync --reinstall-package pfsspecsim`), and drop the now-unnecessary manual `make clean` advice when switching compilers.

## Test plan

- [x] `uv sync` with no changes: audited, no rebuild
- [x] `touch src/gsetc_omp.c && uv sync`: project rebuilt, `gsetc_omp.x` recompiled
- [x] `CC=gcc-12 uv sync`: binary links against `gcc@12`'s libgomp (`otool -L`); plain `uv sync` afterwards rebuilds with the autodetected gcc-16
- [x] Executables restored and working in `python/pfsspecsim/bin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)